### PR TITLE
fix: resolve NullReferenceException in postLoad() - fixes #56

### DIFF
--- a/Source code/MscModApi/Caching/Cache.cs
+++ b/Source code/MscModApi/Caching/Cache.cs
@@ -21,9 +21,14 @@ namespace MscModApi.Caching
 		/// <returns></returns>
 		public static GameObject Find(string name, bool findEvenIfInactive = true)
 		{
+			// FIX: Initialize cachedGameObjects if null (defensive programming)
+			if (cachedGameObjects == null)
+			{
+				cachedGameObjects = new Dictionary<string, GameObject>();
+			}
+			
 			try {
-				GameObject gameObject = cachedGameObjects[name];
-				if (gameObject != null) {
+				if (cachedGameObjects.TryGetValue(name, out GameObject gameObject) && gameObject != null) {
 					return gameObject;
 				}
 			}

--- a/Source code/MscModApi/MscModApi.cs
+++ b/Source code/MscModApi/MscModApi.cs
@@ -131,7 +131,15 @@ namespace MscModApi
 
 		private void PostLoad()
 		{
-			replacedGamePartsDelayedInitializer.InitOnceByUpdateFrame();
+			// FIX: Added null check for replacedGamePartsDelayedInitializer
+			if (replacedGamePartsDelayedInitializer != null)
+			{
+				replacedGamePartsDelayedInitializer.InitOnceByUpdateFrame();
+			}
+			else
+			{
+				ModConsole.Warning("[MscModApi] ReplacedGamePartsDelayedInitializer is null in PostLoad. This may indicate PreLoad was not executed properly.");
+			}
 		}
 
 		private void Save()

--- a/Source code/MscModApi/Parts/ReplacePart/ReplacedGameParts.cs
+++ b/Source code/MscModApi/Parts/ReplacePart/ReplacedGameParts.cs
@@ -726,17 +726,47 @@ namespace MscModApi.Parts.ReplacePart
 
 		public static void Save()
 		{
+			// FIX: Added null check for modsParts
+			if (modsParts == null)
+			{
+				return;
+			}
+			
 			foreach (var modParts in modsParts)
 			{
+				// FIX: Skip if value is null
+				if (modParts.Value == null)
+				{
+					continue;
+				}
+				
 				var mod = Helper.GetMod(modParts.Key);
+				
+				// FIX: Skip if mod is null
+				if (mod == null)
+				{
+					continue;
+				}
 
 				// Dictionary<replacedGameParts-id, Dictionary<gamePart-id, GamePartSave>>
 				var modPartSaves = new Dictionary<string, Dictionary<string, GamePartSave>>();
 
 				foreach (ReplacedGameParts replacedGameParts in modParts.Value)
 				{
+					// FIX: Skip if replacedGameParts or originalParts is null
+					if (replacedGameParts?.originalParts == null)
+					{
+						continue;
+					}
+					
 					foreach (var originalPart in replacedGameParts.originalParts)
 					{
+						// FIX: Skip if originalPart is null
+						if (originalPart == null)
+						{
+							continue;
+						}
+						
 						if (modPartSaves.TryGetValue(replacedGameParts.id, out var gamePartSaves))
 						{
 							gamePartSaves.Add(originalPart.id, originalPart.saveData);

--- a/Source code/MscModApi/Parts/ReplacePart/ReplacedGamePartsDelayedInitializer.cs
+++ b/Source code/MscModApi/Parts/ReplacePart/ReplacedGamePartsDelayedInitializer.cs
@@ -21,7 +21,23 @@ namespace MscModApi.Parts.ReplacePart
 		private const int SECONDS_TO_WAIT = 6;
 
 		private bool initialized;
-		private bool initializingRequired => ReplacedGameParts.modsParts.Any(keyValuePair => keyValuePair.Value.Count > 0);
+		
+		/// <summary>
+		/// Checks if any ReplacedGameParts need to be initialized.
+		/// Returns false if modsParts is null or empty.
+		/// </summary>
+		private bool initializingRequired
+		{
+			get
+			{
+				// FIX: Added null check for modsParts to prevent NullReferenceException
+				if (ReplacedGameParts.modsParts == null)
+				{
+					return false;
+				}
+				return ReplacedGameParts.modsParts.Any(keyValuePair => keyValuePair.Value != null && keyValuePair.Value.Count > 0);
+			}
+		}
 
 		private IEnumerator AwaitGameProperlyInitialized()
 		{
@@ -35,19 +51,43 @@ namespace MscModApi.Parts.ReplacePart
 				yield return null;
 			}
 
-			if (ReplacedGameParts.modsParts.Count == 0)
+			// FIX: Added null check for modsParts
+			if (ReplacedGameParts.modsParts == null || ReplacedGameParts.modsParts.Count == 0)
 			{
 				yield break;
 			}
 
 			float currentTime = 0;
-			FsmBool playerStop = FsmVariables.GlobalVariables.FindFsmBool("PlayerStop");
-			playerStop.Value = true;
+			
+			// FIX: Added null checks for FsmVariables.GlobalVariables and playerStop
+			FsmBool playerStop = null;
+			try
+			{
+				if (FsmVariables.GlobalVariables != null)
+				{
+					playerStop = FsmVariables.GlobalVariables.FindFsmBool("PlayerStop");
+				}
+			}
+			catch (Exception ex)
+			{
+				ModConsole.Error($"[MscModApi] Failed to find PlayerStop FsmBool: {ex.Message}");
+			}
+			
+			// Only set playerStop if it was found successfully
+			if (playerStop != null)
+			{
+				playerStop.Value = true;
+			}
+			else
+			{
+				ModConsole.Warning("[MscModApi] PlayerStop FsmBool not found, skipping movement lock during initialization");
+			}
 
 			while (currentTime < SECONDS_TO_WAIT)
 			{
 				currentTime += Time.deltaTime;
-				if (playerStop.Value)
+				// FIX: Added null check before accessing playerStop.Value
+				if (playerStop != null && playerStop.Value)
 				{
 					int secondsLeft = (int) Math.Floor(SECONDS_TO_WAIT - currentTime);
 					if (secondsLeft <= 0)
@@ -55,31 +95,60 @@ namespace MscModApi.Parts.ReplacePart
 						secondsLeft = 0;
 					}
 					UserInteraction.GuiInteraction(UserInteraction.Type.None, $"MscModApi waiting for game finished loading ~{secondsLeft} seconds. Press [{cInput.GetText("Use")}] to force unlock movement");
-					if (UserInteraction.UseButtonDown || MscModApi.disableLoadingMovementLock.GetValue())
+					// FIX: Added null check for MscModApi.disableLoadingMovementLock
+					bool disableMovementLock = MscModApi.disableLoadingMovementLock != null && MscModApi.disableLoadingMovementLock.GetValue();
+					if (UserInteraction.UseButtonDown || disableMovementLock)
 					{
 						playerStop.Value = false;
 					}
 				}
 				yield return null;
 			}
-			playerStop.Value = false;
+			// FIX: Added null check before setting playerStop.Value
+			if (playerStop != null)
+			{
+				playerStop.Value = false;
+			}
+
+			// FIX: Added null check for modsParts before iterating
+			if (ReplacedGameParts.modsParts == null)
+			{
+				yield break;
+			}
 
 			foreach (KeyValuePair<string, List<ReplacedGameParts>> keyValuePair in ReplacedGameParts.modsParts)
 			{
+				// FIX: Skip if value is null
+				if (keyValuePair.Value == null)
+				{
+					continue;
+				}
+				
 				int modInitializedCounter = 0;
 				int modInitializedFailureCounter = 0;
 				foreach (ReplacedGameParts replacedGameParts in keyValuePair.Value)
 				{
+					// FIX: Skip if replacedGameParts is null
+					if (replacedGameParts == null)
+					{
+						continue;
+					}
+					
 					if (!replacedGameParts.initialized)
 					{
 						try
 						{
-							replacedGameParts.GetEvents(ReplacedGamePartsEvent.Type.Initialized).InvokeAll();
+							var events = replacedGameParts.GetEvents(ReplacedGamePartsEvent.Type.Initialized);
+							// FIX: Added null check for events
+							if (events != null)
+							{
+								events.InvokeAll();
+							}
 							modInitializedCounter++;
 						}
 						catch (Exception ex)
 						{
-							ModConsole.Print($"Executing Initializing events for ReplacedGamePart with id '{replacedGameParts.id} failed. Check your Events'");
+							ModConsole.Print($"Executing Initializing events for ReplacedGamePart with id '{replacedGameParts.id}' failed. Check your Events");
 							ModConsole.Error(ex.Message);
 							modInitializedFailureCounter++;
 						}
@@ -105,7 +174,15 @@ namespace MscModApi.Parts.ReplacePart
 			}
 
 			initialized = true;
-			StartCoroutine(AwaitGameProperlyInitialized());
+			
+			try
+			{
+				StartCoroutine(AwaitGameProperlyInitialized());
+			}
+			catch (Exception ex)
+			{
+				ModConsole.Error($"[MscModApi] Failed to start initialization coroutine: {ex.Message}");
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Bugfix Summary for Issue #56

## Problem Description
The MscModApi module was crashing with a NullReferenceException in `postLoad()` method, causing the mod to be disabled completely.

**Error Message:**
```
Error: The object reference is not set for the object instance in Void postLoad()
Error: The MscModApi module is disabled! Because it gives out too many errors in every frame!
```

## Root Cause Analysis

The main issue was in `ReplacedGamePartsDelayedInitializer.cs` where several objects were accessed without null checks:

1. **`FsmVariables.GlobalVariables.FindFsmBool("PlayerStop")`** - The PlayMaker FSM variables might not be initialized when PostLoad() is called
2. **`ReplacedGameParts.modsParts`** - Could be null if `LoadCleanup()` wasn't called or failed
3. **`replacedGamePartsDelayedInitializer`** - Could be null if `PreLoad()` wasn't executed

## Files Modified

### 1. `Source code/MscModApi/Parts/ReplacePart/ReplacedGamePartsDelayedInitializer.cs`

**Changes:**
- ✅ Added null check for `ReplacedGameParts.modsParts` in `initializingRequired` property
- ✅ Added null check for `FsmVariables.GlobalVariables` before calling `FindFsmBool()`
- ✅ Added null check for `playerStop` before accessing `.Value`
- ✅ Added null check for `MscModApi.disableLoadingMovementLock` setting
- ✅ Added null checks when iterating over `modsParts` collections
- ✅ Added null check for events before calling `InvokeAll()`
- ✅ Wrapped coroutine start in try-catch for better error handling
- ✅ Added warning messages instead of crashing when FsmBool is not found

### 2. `Source code/MscModApi/MscModApi.cs`

**Changes:**
- ✅ Added null check for `replacedGamePartsDelayedInitializer` in `PostLoad()`
- ✅ Added warning message when the initializer is null

### 3. `Source code/MscModApi/Parts/ReplacePart/ReplacedGameParts.cs`

**Changes:**
- ✅ Added null check for `modsParts` in `Save()` method
- ✅ Added null checks for `modParts.Value`, `mod`, `replacedGameParts`, and `originalPart`
- ✅ Skip iterations gracefully instead of throwing exceptions

### 4. `Source code/MscModApi/Caching/Cache.cs`

**Changes:**
- ✅ Added defensive initialization of `cachedGameObjects` if null
- ✅ Changed dictionary access to use `TryGetValue` instead of direct indexer

## Testing Recommendations

1. Test mod loading with a fresh game save
2. Test mod loading with an existing save
3. Test mod loading when other mods are also installed
4. Test the "Disable movement lock while loading" option
5. Verify no errors appear in the console during loading

## Breaking Changes

None. All changes are backward compatible and add defensive programming without changing the API.

## Additional Improvements Made

1. Better error messages with `[MscModApi]` prefix for easier debugging
2. Graceful degradation - the mod will now warn instead of crash when non-critical features fail
3. Fixed a typo in error message (`'{replacedGameParts.id}` → `'{replacedGameParts.id}'`)
